### PR TITLE
Add Windows BAT file alternative to create_binfiles_from_nand.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ directory:
 - `otp.bin` - The associated OTP/fused memory dumped from your console
 - `seeprom.bin` - The associated SEEPROM memory dumped from your console
 
-The included script `create_binfiles_from_nand.sh` will generate otp.bin and seeprom.bin for you using your nand.bin
+The included script `create_binfiles_from_nand.sh`/`create_binfiles_from_nand.bat` will generate otp.bin and seeprom.bin for you using your nand.bin
 
 You can run the emulator with the interpreter backend like this:
 ```

--- a/create_binfiles_from_nand.bat
+++ b/create_binfiles_from_nand.bat
@@ -1,0 +1,23 @@
+@echo off
+setlocal
+
+if not exist "nand.bin" (
+  echo ERROR: nand.bin not found in %CD%
+  exit /b 1
+)
+
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+  "$ErrorActionPreference='Stop';" ^
+  "; function Copy-Bytes([string]$src,[long]$off,[int]$len,[string]$dst) {" ^
+  "    $fs=[System.IO.File]::Open($src,'Open','Read');" ^
+  "    try { $fs.Seek($off,'Begin') > $null; $buf=New-Object byte[] $len; $r=$fs.Read($buf,0,$len) } finally { $fs.Close() }" ^
+  "    [System.IO.File]::WriteAllBytes($dst,$buf[0..($r-1)])" ^
+  "}" ^
+  "; Copy-Bytes 'nand.bin' 553648128 1024 'keys.bin'" ^
+  "; Copy-Bytes 'keys.bin' 256 128 'otp.bin'" ^
+  "; Copy-Bytes 'keys.bin' 512 256 'seeprom.bin'" ^
+  "; $fs=[System.IO.File]::Open('keys.bin','Open','Read');" ^
+  "   try { $buf=New-Object byte[] 256; $r=$fs.Read($buf,0,256) } finally { $fs.Close() }" ^
+  "   $stdout=[Console]::OpenStandardOutput(); $stdout.Write($buf,0,$r); $stdout.Flush()"
+
+endlocal


### PR DESCRIPTION
This is mainly useful for Windows users. Seems to work just as well as the macOS/Linux alternative.
I also update README.md to mention the create binfiles BAT script because it was previously not there, and was added in the commit.