### PR TITLE
Improve SD Host Contoller & Card emulation

### DIFF
--- a/core/src/dev/sdhc.rs
+++ b/core/src/dev/sdhc.rs
@@ -3,19 +3,13 @@ pub(crate) mod card;
 
 use anyhow::anyhow;
 use anyhow::bail;
-use log::debug;
-use log::error;
-use log::log_enabled;
-use log::trace;
+use log::{trace, debug, warn, error};
 
 use crate::bus::prim::*;
 use crate::bus::mmio::*;
 use crate::bus::task::*;
 use crate::bus::Bus;
 use card::*;
-
-/// Changing this to false will disable DMA support
-const SDHC_ENABLE_DMA: bool = true;
 
 #[derive(Debug)]
 pub enum SDHCTask {
@@ -59,7 +53,11 @@ enum SDRegisters {
 }
 
 impl SDRegisters {
-    // writes are always 32 bit, but some registers are smaller than that, so we need to test old and new
+    /// Writes are always 32 bit, but some registers are smaller than that
+    /// So we need to shift and mask the old value with the new value to determine which registers are affected
+    ///
+    /// Returns Vec as up to 4 8 bit registers could be updated in a single shot, but this is unlikely to happen in practice
+    /// Most Host Drivers only write to a single register at a time.
     fn get_affected_registers(off: usize, old: u32, new: u32) -> Vec<SDRegisters> {
         let mut ret = Vec::with_capacity(4);
         let mut shift = 0u32;
@@ -176,7 +174,7 @@ impl SDRegisters {
             SDRegisters::HostControllerVersion => 2,
         }
     }
-    // These registers have RW1C bits or additional logic that must run on any write, even if the register is ultimiately unchanged
+    /// These registers have RW1C bits or additional logic that must run on any write, even if the register is ultimiately unchanged
     fn must_always_handle_writes(&self) -> bool {
         matches!(self,
             SDRegisters::BufferDataPort |
@@ -204,10 +202,7 @@ impl SDRegisters {
         match self {
             SDRegisters::Command => {
                 let x = card::Command::from(new);
-                if log_enabled!(target: "SDHC", log::Level::Debug) {
-                    dbg!(&x);
-                }
-                // let cmd = x.index;
+                debug!(target: "SDHC", "Command {:?}", &x);
                 if let Some(response) = iface.card.issue(x, iface.raw_read(SDRegisters::Argument.base_offset())){
                     self.apply_response(iface, response);
                 }
@@ -229,10 +224,6 @@ impl SDRegisters {
                         if new & 1 == 1 {
                             let use_dma = iface.raw_read(SDRegisters::TxMode.base_offset()) & 0x1 == 1;
                             if use_dma {
-                                if !SDHC_ENABLE_DMA {
-                                    error!(target:"SDHC", "Software Attempted to use DMA, which is disabled.");
-                                    return None;
-                                }
                                 iface.card.tx_status = CardTXStatus::DMAReadInProgress;
                                 return Some(SDHCTask::DoDMARead);
                             }
@@ -246,10 +237,6 @@ impl SDRegisters {
                         if new & 1 == 1 {
                             let use_dma = iface.raw_read(SDRegisters::TxMode.base_offset()) & 0x1 == 1;
                             if use_dma {
-                                if !SDHC_ENABLE_DMA {
-                                    error!(target:"SDHC", "Software Attempted to use DMA, which is disabled.");
-                                    return None;
-                                }
                                 iface.card.tx_status = CardTXStatus::DMAWriteInProgress;
                                 return Some(SDHCTask::DoDMAWrite);
                             }
@@ -298,10 +285,17 @@ impl SDRegisters {
                 iface.setreg(*self, new);
             },
             SDRegisters::SoftwareReset => {
-                if new & 1 == 1 {
-                    iface.reset();
+                if new & 0b001 != 0 {
+                    iface.reset_all();
                 }
-                else { unimplemented!("DAT and CMD line resets"); }
+                else {
+                    if new & 0b010 != 0 {
+                        iface.reset_cmd_line();
+                    }
+                    if new & 0b100 != 0 {
+                        iface.reset_dat_line();
+                    }
+                }
             },
             SDRegisters::BufferDataPort => {
                 match iface.card.tx_status {
@@ -338,6 +332,7 @@ impl SDRegisters {
                     }
                 }
             }
+            SDRegisters::HostControl |
             SDRegisters::TxMode |
             SDRegisters::BlockCount |
             SDRegisters::BlockSize |
@@ -350,7 +345,7 @@ impl SDRegisters {
                 iface.setreg(*self, new);
             },
             other => {
-                error!(target: "SDHC", "Unhandled write to register: {other:?}");
+                warn!(target: "SDHC", "Unhandled write to register: {other:?}");
                 iface.setreg(*other, new);
             }
         }
@@ -378,7 +373,6 @@ pub struct SDInterface {
     insert_raised: bool,
     first_ack: bool,
     card: Card,
-    card_available: bool,
     tx_status: CardTXStatus,
 }
 
@@ -455,16 +449,67 @@ impl SDInterface {
             false
         }
     }
-    fn reset(&mut self) {
-        debug!(target: "SDHC", "SD interface software reset");
+    fn reset_all(&mut self) {
+        debug!(target: "SDHC", "SD interface software reset for ALL");
         let mut new = Self::default();
         let card_detection_circuit_status = self.raw_read(SDRegisters::PresentState.base_offset()) & 0x70000;
         new.raw_write(SDRegisters::PresentState.base_offset(), card_detection_circuit_status);
         new.insert_raised = self.insert_raised;
         *self = new;
     }
+    fn reset_cmd_line(&mut self) {
+        debug!(target: "SDHC", "SD interface software reset for CMD line");
+        // Clear the following bits in Present State Register
+        // - Command Inhibit (CMD) bit 0
+        let ps = self.raw_read(SDRegisters::PresentState.base_offset());
+        const PS_CMD_RESET: u32 = 0x1;
+        self.setreg(SDRegisters::PresentState, ps & !PS_CMD_RESET);
+        // Clear the following bits in Normal Interrupt Status Register
+        // - Command Complete bit 0
+        let nisr = self.raw_read(SDRegisters::NormalIntStatus.base_offset()) & 0x0000_ffff;
+        const NISR_CMD_RESET: u32 = 0x1;
+        self.setreg(SDRegisters::NormalIntStatus, nisr & !NISR_CMD_RESET);
+        // In case any of these got stashed, clear from pending interrupts as well
+        self.pending_interrupt_flags &= !NISR_CMD_RESET;
+    }
+    fn reset_dat_line(&mut self) {
+        debug!(target: "SDHC", "SD interface software reset for DAT line");
+        // Clear & init Buffer Data Port
+        self.setreg(SDRegisters::BufferDataPort, 0);
+        // Clear the following bits in Present State Register
+        // - Buffer Read Enable     bit 11
+        // - Buffer Write Enable    bit 10
+        // - Read Transfer Active   bit  9
+        // - Write Transfer Active  bit  8
+        // - DAT Line Active        bit  2
+        // - Command Inhibit (DAT)  bit  1
+        let ps = self.raw_read(SDRegisters::PresentState.base_offset());
+        const PS_DAT_RESET: u32 = 0xF06;
+        self.setreg(SDRegisters::PresentState, ps & !PS_DAT_RESET);
+        // Clear the following bits in Block Gap Control Register
+        // - Continue Request          bit 1
+        // - Stop at Block Gap Request bit 0
+        let bgcr = (self.raw_read(SDRegisters::BlockGapControl.base_offset() & 0xffff_fffc) & 0x00ff_0000) >> 16;
+        const BG_DAT_RESET: u32 = 0x3;
+        self.setreg(SDRegisters::BlockGapControl, bgcr & !BG_DAT_RESET);
+        // Clear the following bits in Normal Interrupt Status Register
+        // - Buffer Read Ready  bit 5
+        // - Buffer Write Ready bit 4
+        // - DMA Interrupt      bit 3
+        // - Block Gap Event    bit 2
+        // - Transfer complete  bit 1
+        let nisr = self.raw_read(SDRegisters::NormalIntStatus.base_offset()) & 0x0000_ffff;
+        const NISR_DAT_RESET: u32 = 0x3E;
+        self.setreg(SDRegisters::NormalIntStatus, nisr & !NISR_DAT_RESET);
+        // In case any of these got stashed, clear from pending interrupts as well
+        self.pending_interrupt_flags &= !NISR_DAT_RESET;
+        // Spec tells us to "Reset DMA circuit" as well.
+        // Not really sure what that means *exactly*, but we will clear any transactions in progress with the card
+        // This may cause errors to be logged to the console, but shouldn't be a big deal otherwise.
+        self.card.tx_status = CardTXStatus::None;
+    }
     fn insert_card(&mut self) -> bool {
-        if self.insert_raised || !self.card_available {
+        if self.insert_raised || !self.card.available {
             return false;
         }
         let current_state = self.raw_read(SDRegisters::PresentState.base_offset());
@@ -505,7 +550,7 @@ impl SDInterface {
         return self.raise_int(BUFFER_READ_READY_MASK);
     }
     fn buffer_ready_write(&mut self) -> bool {
-        let blocks_remaining = self.raw_read(SDRegisters::BlockCount.base_offset() & 0xffff_fffc) >> 16; // p83
+        let blocks_remaining = self.raw_read(SDRegisters::BlockCount.base_offset() & 0xffff_fffc) >> 16;
         if blocks_remaining > 0 {
             // tell card it's rw_stop
             self.card.rw_stop = self.card.rw_index.load(std::sync::atomic::Ordering::Relaxed) + 512;
@@ -601,19 +646,19 @@ impl SDInterface {
 
 impl Default for SDInterface {
     fn default() -> Self {
-        let (card, card_available) = Card::try_new();
-        let mut new = Self { register_file: [0;256], pending_interrupt_flags: 0, insert_raised: false, first_ack: false, card, card_available, tx_status: CardTXStatus::None };
+        let card = Card::new();
+        let mut new = Self { register_file: [0;256], pending_interrupt_flags: 0, insert_raised: false, first_ack: false, card, tx_status: CardTXStatus::None };
         // Fill HWInit registers
         // Capabilities Register
         const VOLTAGE_SUPPORT_3_3V: u32 = 1 << 24;
         const SD_BASE_CLK_10MHZ: u32 = 10 << 8;
-        const DMA_SUPPORT: u32 = (SDHC_ENABLE_DMA as u32) << 22;
+        const DMA_SUPPORT: u32 = 1 << 22;
         new.raw_write(SDRegisters::Capabilities.base_offset(), VOLTAGE_SUPPORT_3_3V | SD_BASE_CLK_10MHZ | DMA_SUPPORT);
         // Maximum Current Capabilities Register
         const CURRENT_CAP_3_3V_MAX: u32 = 0xff;
         new.raw_write(SDRegisters::MaxCurrentCapabilities.base_offset(), CURRENT_CAP_3_3V_MAX);
         // End HWInit Registers
-        debug!(target: "SDHC", "init sdhc");
+        debug!(target: "SDHC", "SD Interface Initialized");
         new
     }
 }
@@ -636,7 +681,7 @@ impl MmioDevice for SDInterface {
                     {
                         let v = self.card.backing_mem.lock();
                         if v.data.len() < index+4 || index+4 > self.card.rw_stop {
-                            return Err(anyhow!("out of range! {index:?} {:?} {} ", v.data.len(), self.card.rw_stop));
+                            return Err(anyhow!("SDHC read out of range! {index:?} data len: {:?} rw_stop: {} ", v.data.len(), self.card.rw_stop));
                         }
                         self.card.rw_index.store(index+4, std::sync::atomic::Ordering::Relaxed);
                         let ret: u32 = v.read(index).unwrap();
@@ -650,23 +695,21 @@ impl MmioDevice for SDInterface {
 
     fn write(&mut self, off: usize, val: Self::Width) -> anyhow::Result<Option<BusTask>> {
         debug!(target: "SDHC", "MMIO write: 0x{off:x} = 0x{val:x}");
-        // first read the current line to get the old
         let old = self.raw_read(off);
         let regs = SDRegisters::get_affected_registers(off, old, val);
-        debug!(target: "SDHC", "{:?}", &regs);
-        //fixme: multiple tasks?
-        let mut tasks = Vec::new();
+        debug!(target: "SDHC", "affected registers: {:?}", &regs);
+        let mut send_task = None;
         for reg in regs {
             if let Some(task) = reg.run_write_handler(self, old, val) {
-                tasks.push(task);
+                if send_task.is_none() {
+                    send_task = Some(BusTask::SDHC(task));
+                }
+                else {
+                    error!(target: "SDHC", "Multiple SDHC Tasks returned from a single write. This is not supported.");
+                }
             }
         }
-        if tasks.is_empty() {
-            Ok(None)
-        }
-        else {
-            Ok(Some(BusTask::SDHC(tasks.pop().unwrap())))
-        }
+        return Ok(send_task);
     }
 }
 

--- a/core/src/dev/sdhc/card.rs
+++ b/core/src/dev/sdhc/card.rs
@@ -1,7 +1,31 @@
 use std::{num::NonZeroU16, sync::atomic::AtomicUsize};
-use log::{debug, error};
+use log::{debug, error, warn};
 
 use crate::mem::BigEndianMemory;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CardCapacity {
+    /// Standard Capacity SD Memory Card (up to and including 2 GB).
+    /// Uses byte addressing for memory access commands.
+    /// Uses CSD Version 1.0.
+    /// Does not respond to CMD8 (presents as a v1.x card).
+    StandardCapacity,
+    /// High Capacity SD Memory Card (more than 2 GB, up to 32 GB).
+    /// Uses block (512 byte) addressing for memory access commands.
+    /// Uses CSD Version 2.0.
+    /// Responds to CMD8.
+    HighCapacity,
+}
+impl CardCapacity {
+    fn from_bytes(len: usize) -> Self {
+        const TWO_GB: usize = 2 * 1024 * 1024 * 1024;
+        if len > TWO_GB {
+            CardCapacity::HighCapacity
+        } else {
+            CardCapacity::StandardCapacity
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// The Transaction State of the emulated SD card.
@@ -76,6 +100,7 @@ impl CommandType {
 use parking_lot::Mutex;
 #[derive(Debug)]
 pub(super) struct Card {
+    pub available: bool,
     pub state: CardState,
     pub backing_mem: Mutex<BigEndianMemory>,
     acmd: bool,
@@ -84,6 +109,8 @@ pub(super) struct Card {
     /// Relative Card Address. The Host Driver will help us assign one and then use this to select us as the Active card.
     rca: Option<NonZeroU16>,
     csd: CsdReg,
+    /// Whether this card is SDSC (<=2GB) or SDHC (>2GB).
+    pub capacity: CardCapacity,
     /// The Card is selected by the Host Driver
     selected: bool,
     /// Pointer into the Backing Mem to keep track of multi-block transfers
@@ -94,7 +121,7 @@ pub(super) struct Card {
 }
 
 impl Card {
-    pub(super) fn try_new() -> (Self, bool) {
+    pub(super) fn new() -> Self {
         const FILENAME: &str = "sd.img";
         let mut len = 0usize;
         let backing_mem: BigEndianMemory;
@@ -111,19 +138,23 @@ impl Card {
             card_inserted = false;
             backing_mem = BigEndianMemory::new(len, None, false).unwrap();
         }
-        (Self {
+        let capacity = CardCapacity::from_bytes(len);
+        debug!(target: "SDHC", "SD card image size: {} bytes, capacity type: {:?}", len, capacity);
+        Self {
+            available: card_inserted,
             state: Default::default(),
             backing_mem: Mutex::new(backing_mem),
             acmd: Default::default(),
-            ocr: Default::default(),
+            ocr: OcrReg::new(capacity),
             cid: Default::default(),
             rca: Default::default(),
-            csd: CsdReg::new_with_num_block(len / 512),
+            csd: CsdReg::new(len, capacity),
+            capacity,
             selected: Default::default(),
             rw_index: Default::default(),
             rw_stop: Default::default(),
             tx_status: Default::default()
-        }, card_inserted)
+        }
     }
 }
 
@@ -133,9 +164,7 @@ impl Card {
         let acmd = std::mem::replace(&mut self.acmd, false);
         match (acmd, cmd.index) {
             (false, 0) => { return Some(self.cmd0(argument)); },
-            (false, 8) => {
-                return Some(self.cmd8(argument));
-            },
+            (false, 8) => { return self.cmd8(argument); },
             (true, 41) => { return Some(self.acmd41(argument)); },
             (false, 2) => { return Some(self.cmd2(argument)); },
             (false, 3) => { return Some(self.cmd3(argument)); },
@@ -155,9 +184,15 @@ impl Card {
             },
         }
     }
-    fn cmd8(&mut self, argument: u32) -> Response {
-        // CMD8 echo back in response
-        Response::Regular(argument & 0xfff)
+    fn cmd8(&mut self, argument: u32) -> Option<Response> {
+        match self.capacity {
+            CardCapacity::HighCapacity => {
+                Some(Response::Regular(argument & 0xfff))
+            },
+            CardCapacity::StandardCapacity => {
+                None
+            },
+        }
     }
     fn cmd0(&mut self, _argument: u32) -> Response {
         self.state = CardState::Idle;
@@ -213,22 +248,33 @@ impl Card {
     fn cmd16(&self, argument: u32) -> Response {
         let mut response = (self.state.bits_for_card_status() as u32) << 9;
         if argument != 512 {
+            error!(target: "SDHC", "CMD16 with block len != 512 is not currently supported");
             response |= 1 << 29; // block len error
         }
         Response::Regular(response)
     }
+    /// SDHC: argument is a block address
+    /// SDSC: argument is already a byte address
+    fn argument_to_byte_offset(&self, argument: u32) -> usize {
+        match self.capacity {
+            CardCapacity::HighCapacity => argument as usize * 512,
+            CardCapacity::StandardCapacity => argument as usize,
+        }
+    }
     fn cmd18(&mut self, argument: u32) -> Response {
-        log::debug!(target: "SDHC", "Issued multi block transfer(R): {} bytes", argument * 512);
+        let byte_offset = self.argument_to_byte_offset(argument);
+        log::debug!(target: "SDHC", "Issued multi block transfer(R): byte offset {} (arg=0x{:x}, {:?})", byte_offset, argument, self.capacity);
         self.state = CardState::Data;
-        self.rw_index.store(argument as usize * 512 , std::sync::atomic::Ordering::Relaxed);
+        self.rw_index.store(byte_offset, std::sync::atomic::Ordering::Relaxed);
         let response = (self.state.bits_for_card_status() as u32) << 9;
         self.tx_status = CardTXStatus::MultiReadPending;
         Response::Regular(response)
     }
     fn cmd25(&mut self, argument: u32) -> Response {
-        log::debug!(target: "SDHC", "Issued multi block transfer(W): {} bytes", argument * 512);
+        let byte_offset = self.argument_to_byte_offset(argument);
+        log::debug!(target: "SDHC", "Issued multi block transfer(W): byte offset {} (arg=0x{:x}, {:?})", byte_offset, argument, self.capacity);
         self.state = CardState::Rcv;
-        self.rw_index.store(argument as usize * 512 , std::sync::atomic::Ordering::Relaxed);
+        self.rw_index.store(byte_offset, std::sync::atomic::Ordering::Relaxed);
         let response = (self.state.bits_for_card_status() as u32) << 9;
         self.tx_status = CardTXStatus::MultiWritePending;
         Response::Regular(response)
@@ -292,18 +338,21 @@ impl CardState {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// Operation Condition Register of the emulated SD card.
+/// Mostly does not matter.
 struct OcrReg(u32);
 
-impl Default for OcrReg {
-    fn default() -> Self {
-        Self((1 << 31 /* powerup complete */) | (1 << 30 /* High capacity card */) | (1 << 20 /* 3.3v */))
+impl OcrReg {
+    fn new(capacity: CardCapacity) -> Self {
+        let ccs = match capacity {
+            CardCapacity::HighCapacity => 1 << 30, // CCS = 1: High Capacity
+            CardCapacity::StandardCapacity => 0,    // CCS = 0: Standard Capacity
+        };
+        Self((1 << 31 /* powerup complete */) | ccs | (1 << 20 /* 3.3v */))
     }
 }
 
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-/// Operation Condition Register of the emulated SD card.
-/// Mostly does not matter.
 struct CidReg(u128);
 
 impl Default for CidReg {
@@ -322,7 +371,16 @@ impl Default for CidReg {
 struct CsdReg(u128);
 
 impl CsdReg {
-    fn new_with_num_block(num_blocks: usize) -> Self {
+    fn new(len: usize, capacity: CardCapacity) -> Self {
+        match capacity {
+            CardCapacity::HighCapacity => Self::new_v2(len / 512),
+            CardCapacity::StandardCapacity => Self::new_v1(len),
+        }
+    }
+
+    /// Build CSD Version 2.0 for SDHC cards (>2GB).
+    /// C_SIZE is in units of 512KB: memory capacity = (C_SIZE+1) * 512K byte
+    fn new_v2(num_blocks: usize) -> Self {
         let num_blocks = ((num_blocks & 0x3fffff) + 1) as u128; // mask to 22 bit, spec builds in an additional +1 as well.
         let x =
             (1 << 126) | //structure ver 2
@@ -338,5 +396,129 @@ impl CsdReg {
             (3 << 10) // file format other
         ;
         Self(x >> 8) /* mini is off, or we are - probably us!! */
+    }
+
+    /// Build CSD Version 1.0 for SDSC cards (<=2GB).
+    /// Uses the C_SIZE / C_SIZE_MULT / READ_BL_LEN encoding per SD Physical Layer spec Table 5-4.
+    ///
+    /// memory capacity = BLOCKNR * BLOCK_LEN
+    /// BLOCKNR = (C_SIZE+1) * MULT
+    /// MULT = 2^(C_SIZE_MULT+2)
+    /// BLOCK_LEN = 2^READ_BL_LEN
+    fn new_v1(len: usize) -> Self {
+        // ?? worth supporting oddly sized cards ??
+        //
+        // C_SIZE is 12 bits (0..4095), C_SIZE_MULT is 3 bits (0..7), READ_BL_LEN is 9,10, or 11.
+        //
+        // try READ_BL_LEN = 9 (512 bytes) first, then 10 (1024), then 11 (2048).
+        // for each, try C_SIZE_MULT from 0..7.
+        // Pick the first combination that works.
+        //
+        let mut read_bl_len: u128 = 9;
+        let mut c_size: u128 = 0;
+        let mut c_size_mult: u128 = 0;
+        let mut found = false;
+
+        for bl_len in [9u32, 10, 11] {
+            let block_len = 1usize << bl_len;
+            if len % block_len != 0 {
+                continue;
+            }
+            let total_blocks = len / block_len;
+            for mult_val in 0u32..=7 {
+                let mult = 1usize << (mult_val + 2);
+                if total_blocks % mult != 0 {
+                    continue;
+                }
+                let cs = (total_blocks / mult) - 1; // C_SIZE = BLOCKNR/MULT - 1
+                if cs <= 0xFFF { // C_SIZE fits in 12 bits
+                    read_bl_len = bl_len as u128;
+                    c_size = cs as u128;
+                    c_size_mult = mult_val as u128;
+                    found = true;
+                    break;
+                }
+            }
+            if found { break; }
+        }
+
+        if !found {
+            // Fallback: pick something reasonable. Use 512-byte blocks and max out C_SIZE_MULT.
+            // This handles odd-sized images by rounding down
+            let block_len = 512usize;
+            let mult = 1usize << 9; // C_SIZE_MULT=7 -> MULT=512
+            let total_blocks = len / block_len;
+            c_size = ((total_blocks / mult).saturating_sub(1).min(0xFFF)) as u128;
+            c_size_mult = 7;
+            read_bl_len = 9;
+            warn!(target: "SDHC", "CSD v1: using fallback encoding, capacity may not match exactly");
+        }
+
+        debug!(target: "SDHC", "CSD v1: READ_BL_LEN={}, C_SIZE={}, C_SIZE_MULT={}", read_bl_len, c_size, c_size_mult);
+
+        // CSD v1.0 bit layout (128 bits, [127:0]):
+        //  [127:126] CSD_STRUCTURE = 0 (v1.0)
+        //  [125:120] reserved = 0
+        //  [119:112] TAAC
+        //  [111:104] NSAC
+        //  [103:96]  TRAN_SPEED
+        //  [95:84]   CCC
+        //  [83:80]   READ_BL_LEN
+        //  [79]      READ_BL_PARTIAL = 1
+        //  [78]      WRITE_BLK_MISALIGN = 0
+        //  [77]      READ_BLK_MISALIGN = 0
+        //  [76]      DSR_IMP = 0
+        //  [75:74]   reserved = 0
+        //  [73:62]   C_SIZE (12 bits)
+        //  [61:59]   VDD_R_CURR_MIN
+        //  [58:56]   VDD_R_CURR_MAX
+        //  [55:53]   VDD_W_CURR_MIN
+        //  [52:50]   VDD_W_CURR_MAX
+        //  [49:47]   C_SIZE_MULT (3 bits)
+        //  [46]      ERASE_BLK_EN = 1
+        //  [45:39]   SECTOR_SIZE = 0x7f (128 write blocks)
+        //  [38:32]   WP_GRP_SIZE = 0
+        //  [31]      WP_GRP_ENABLE = 0
+        //  [30:29]   reserved = 0
+        //  [28:26]   R2W_FACTOR = 0b010 (4x)
+        //  [25:22]   WRITE_BL_LEN = READ_BL_LEN
+        //  [21]      WRITE_BL_PARTIAL = 0
+        //  [20:16]   reserved = 0
+        //  [15]      FILE_FORMAT_GRP = 0
+        //  [14]      COPY = 0
+        //  [13]      PERM_WRITE_PROTECT = 0
+        //  [12]      TMP_WRITE_PROTECT = 0
+        //  [11:10]   FILE_FORMAT = 0b11 (other)
+        //  [9:8]     reserved = 0
+        //  [7:1]     CRC = 0 (not checked ????)
+        //  [0]       always 1
+        let x: u128 =
+            (0u128 << 126) |                    // CSD_STRUCTURE = 0 (v1.0)
+            (0x26u128 << 112) |                 // TAAC = 0x26 (1ms, matches typical SDSC)
+            (0x00u128 << 104) |                 // NSAC = 0
+            (0x32u128 << 96) |                  // TRAN_SPEED = 25MHz
+            (0b010110110101u128 << 84) |        // CCC - mandatory classes
+            (read_bl_len << 80) |               // READ_BL_LEN
+            (0u128 << 79) |                     // READ_BL_PARTIAL = 0
+            (0u128 << 78) |                     // WRITE_BLK_MISALIGN = 0
+            (0u128 << 77) |                     // READ_BLK_MISALIGN = 0
+            (0u128 << 76) |                     // DSR_IMP = 0
+            (c_size << 62) |                    // C_SIZE (12 bits)
+            (0b011u128 << 59) |                 // VDD_R_CURR_MIN = 10mA
+            (0b011u128 << 56) |                 // VDD_R_CURR_MAX = 25mA
+            (0b011u128 << 53) |                 // VDD_W_CURR_MIN = 10mA
+            (0b011u128 << 50) |                 // VDD_W_CURR_MAX = 25mA
+            (c_size_mult << 47) |               // C_SIZE_MULT
+            (1u128 << 46) |                     // ERASE_BLK_EN = 1
+            (0x7fu128 << 39) |                  // SECTOR_SIZE = 127 (128 blocks)
+            (0u128 << 32) |                     // WP_GRP_SIZE = 0
+            (0u128 << 31) |                     // WP_GRP_ENABLE = 0
+            (0b010u128 << 26) |                 // R2W_FACTOR = 4x
+            (read_bl_len << 22) |               // WRITE_BL_LEN = READ_BL_LEN
+            (0u128 << 21) |                     // WRITE_BL_PARTIAL = 0
+            (0b11u128 << 10) |                  // FILE_FORMAT = other
+            1u128                               // always 1 bit
+        ;
+        Self(x >> 8) /* fuck me idk */
     }
 }


### PR DESCRIPTION
Looking to do some general fixups & add at least basic SDSC memory card support. This should allow SD Boot to run, barring any other bugs.

Things to do:

- [x] CSD modifications
- [x] CMD8 ignore
- [x] ~~CMD16 support~~
- [x] ~~Use SDSC block sizes in read/write commands~~ No, stick to 512 if possible.
- [ ] Anything I haven't thought of yet.
- [ ] Test it somehow
