### PR TITLE
[WIP] Basic USB Gecko support + required EXI rework

### DIFF
--- a/core/src/dev/hlwd/compat/exi.rs
+++ b/core/src/dev/hlwd/compat/exi.rs
@@ -1,6 +1,11 @@
 pub mod device;
 use anyhow::bail;
+use log::warn;
 use device::*;
+use device::sdgecko::*;
+use device::usbgecko::*;
+use device::rtc::*;
+use device::memorycard::*;
 
 use crate::bus::mmio::*;
 use crate::bus::prim::*;
@@ -27,7 +32,7 @@ impl From<u32> for EXIFreq {
 }
 
 /// Representing an EXI transfer type.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum EXITransfer {
     Read, Write, ReadWrite, Undef,
 }
@@ -35,15 +40,22 @@ impl From<u32> for EXITransfer {
     fn from(x: u32) -> Self {
         match x {
             0b00 => Self::Read,
-            0b10 => Self::Write,
-            0b01 => Self::ReadWrite,
+            0b01 => Self::Write,
+            0b10 => Self::ReadWrite,
             0b11 => Self::Undef,
             _ => unreachable!(),
         }
     }
 }
 
-/// Container for the state associated with an EXI channel, determined by the 
+#[derive(Debug, Clone, Copy)]
+pub enum EXIChannelAction {
+    None,
+    ImmediateTransfer(EXITransferRequest),
+    DmaTransfer,
+}
+
+/// Container for the state associated with an EXI channel, determined by the
 /// current value of the channel's status and control registers.
 #[derive(Debug, Clone, Copy)]
 pub struct ChannelState {
@@ -55,7 +67,9 @@ pub struct ChannelState {
     /// External Insertion Interrupt Mask
     pub ext_msk: bool,
 
-    /// Currently-selected EXI device
+    /// Currently-selected EXI chip-select, if any.
+    pub cs: Option<usize>,
+    /// The logical device mapped to the selected chip-select.
     pub dev: Option<EXIDeviceKind>,
     /// Channel clock frequency
     pub clk: EXIFreq,
@@ -79,7 +93,17 @@ pub struct ChannelState {
     /// Transfer status bit
     pub transfer: bool,
 }
+
 impl ChannelState {
+    fn decode_cs(sts: u32) -> Option<usize> {
+        match (sts & 0x0000_0380) >> 7 {
+            0b001 => Some(0),
+            0b010 => Some(1),
+            0b100 => Some(2),
+            _ => None,
+        }
+    }
+
     fn from_chn(chn: usize, sts: u32, ctrl: u32) -> Self {
         // Status register bits
         let ext     = sts & 0x0000_1000 != 0;
@@ -90,18 +114,19 @@ impl ChannelState {
         let exi_int = sts & 0x0000_0002 != 0;
         let exi_msk = sts & 0x0000_0001 != 0;
 
-        let dev     = EXIDeviceKind::resolve(chn, (sts & 0x0000_0380) >> 7);
+        let cs      = Self::decode_cs(sts);
+        let dev     = cs.and_then(|cs| EXIDeviceKind::resolve(chn, cs));
         let clk     = EXIFreq::from((sts & 0x0000_0070) >> 4);
 
-        // Control register bits
-        let imm_len = (ctrl & 0x0000_0030) >> 4;
-        let transfer_type = EXITransfer::from((ctrl& 0x0000_000c) >> 2);
+        // Control register bits.
+        let imm_len = ((ctrl & 0x0000_0030) >> 4) + 1;
+        let transfer_type = EXITransfer::from((ctrl & 0x0000_000c) >> 2);
         let dma = ctrl & 0x0000_0002 != 0;
         let transfer = ctrl & 0x0000_0001 != 0;
 
         ChannelState {
             ext, ext_int, ext_msk, 
-            dev, clk, 
+            cs, dev, clk,
             tc_int, tc_msk, 
             exi_int, exi_msk,
             imm_len, transfer_type, dma, transfer
@@ -127,12 +152,26 @@ pub struct EXIChannel {
     /// Channel state
     pub state: ChannelState,
 }
+
 impl EXIChannel {
     pub fn new(idx: usize) -> Self {
         EXIChannel {
             idx, csr: 0, mar: 0, len: 0, data: 0, ctrl: 0,
             state: ChannelState::from_chn(idx, 0, 0),
         }
+    }
+
+    fn update_state(&mut self) {
+        self.state = ChannelState::from_chn(self.idx, self.csr, self.ctrl);
+    }
+
+    fn update_csr_device_bits(&mut self, has_device: bool) {
+        if has_device {
+            self.csr |= 0x0000_1000;
+        } else {
+            self.csr &= !0x0000_1000;
+        }
+        self.update_state();
     }
 }
 
@@ -145,52 +184,58 @@ impl EXIChannel {
             0x08 => self.len,
             0x0c => self.ctrl,
             0x10 => self.data,
-            _ => { bail!("EXI chn{} OOB read at {off:08x}", self.idx); },
+            _ => bail!("EXI chn{} OOB read at {off:08x}", self.idx),
         };
         log::debug!(target: "EXI", "chn{} read {res:08x} from offset {off:x}", self.idx);
         Ok(res)
     }
-    pub fn write(&mut self, off: usize, val: u32) -> anyhow::Result<()> {
+
+    pub fn write(&mut self, off: usize, val: u32) -> anyhow::Result<EXIChannelAction> {
         log::debug!(target: "EXI", "chn{} write {val:08x} at {off:08x}", self.idx);
         match off {
-            0x00 => {
-                self.csr = val;
-                self.update_state();
-            }
+            0x00 => self.csr = val,
             0x04 => self.mar = val,
             0x08 => self.len = val,
-            0x0c => {
-                self.ctrl = val;
-                self.update_state();
-            },
+            0x0c => self.ctrl = val,
             0x10 => self.data = val,
-            _ => { bail!("EXI chn{} OOB write {val:08x} at {off:08x}",
-                self.idx); },
+            _ => bail!("EXI chn{} OOB write {val:08x} at {off:08x}", self.idx),
         }
-        Ok(())
-    }
 
-    pub fn update_state(&mut self) {
-        self.state = ChannelState::from_chn(self.idx, self.csr, self.ctrl);
+        self.update_state();
 
-        if self.state.transfer {
-            // FIXME: implement EXI transfers to something (literally anything)
-            self.ctrl &= !1;
-            log::error!(target: "EXI", "Transfer swallowed!");
+        if !matches!(off, 0x00 | 0x0c) || !self.state.transfer {
+            return Ok(EXIChannelAction::None);
         }
+
+        self.ctrl &= !1;
+        self.update_state();
+
+        if self.state.dma {
+            return Ok(EXIChannelAction::DmaTransfer);
+        }
+
+        let Some(cs) = self.state.cs else {
+            return Ok(EXIChannelAction::None);
+        };
+
+        Ok(EXIChannelAction::ImmediateTransfer(EXITransferRequest {
+            channel: self.idx,
+            cs,
+            len: self.state.imm_len,
+            kind: self.state.transfer_type,
+            data: self.data,
+            clk: self.state.clk,
+        }))
     }
 }
-
 
 /// Legacy external interface (EXI).
 #[derive(Debug, Clone)]
 pub struct EXInterface {
-    /// EXI Channel 0 state
-    pub chan0: Box<EXIChannel>,
-    /// EXI Channel 1 state
-    pub chan1: Box<EXIChannel>,
-    /// EXI Channel 2 state
-    pub chan2: Box<EXIChannel>,
+    /// EXI channel state
+    pub channels: [EXIChannel; 3],
+    /// Attached EXI devices by [channel][chip-select]
+    pub devices: [[EXIDeviceSlot; 3]; 3],
     /// Buffer for Broadway bootstrap instructions
     pub ppc_bootstrap: Box<[u32; 0x10]>,
 }
@@ -202,42 +247,79 @@ impl Default for EXInterface {
 }
 
 impl EXInterface {
+    fn build_devices() -> [[EXIDeviceSlot; 3]; 3] {
+        let mut devices = std::array::from_fn(|_| std::array::from_fn(|_| EXIDeviceSlot::None));
+
+        devices[0][0] = EXIDeviceSlot::MemoryCard(MemoryCardDevice);
+        devices[0][1] = EXIDeviceSlot::Rtc(RtcDevice);
+        devices[1][0] = EXIDeviceSlot::UsbGecko(UsbGeckoDevice::default());
+        devices[2][0] = EXIDeviceSlot::SdGecko(SdGeckoDevice);
+
+        devices
+    }
+
     pub fn new() -> Self {
-        EXInterface {
-            chan0: Box::new(EXIChannel::new(0)),
-            chan1: Box::new(EXIChannel::new(1)),
-            chan2: Box::new(EXIChannel::new(2)),
+        let devices = Self::build_devices();
+        let mut exi = Self {
+            channels: [EXIChannel::new(0), EXIChannel::new(1), EXIChannel::new(2)],
+            devices,
             ppc_bootstrap: Box::new([0; 0x10]),
+        };
+        exi.refresh_presence_bits();
+        exi
+    }
+
+    fn refresh_presence_bits(&mut self) {
+        for channel_idx in 0..self.channels.len() {
+            let has_device = self.devices[channel_idx][0].kind().is_some();
+            self.channels[channel_idx].update_csr_device_bits(has_device);
         }
+    }
+
+    fn route_action(&mut self, action: EXIChannelAction) -> anyhow::Result<()> {
+        match action {
+            EXIChannelAction::None => Ok(()),
+            EXIChannelAction::DmaTransfer => {
+                warn!(target: "EXI", "EXI DMA transfers are not supported yet");
+                Ok(())
+            },
+            EXIChannelAction::ImmediateTransfer(req) => {
+                let result = self.devices[req.channel][req.cs].transfer_imm(req)?;
+                self.channels[req.channel].data = result;
+                Ok(())
+            }
+        }
+    }
+
+    fn write_channel(&mut self, channel_idx: usize, off: usize, val: u32) -> anyhow::Result<()> {
+        let action = self.channels[channel_idx].write(off, val)?;
+        self.refresh_presence_bits();
+        self.route_action(action)
     }
 }
 
-
 impl MmioDevice for EXInterface {
     type Width = u32;
+
     fn read(&self, off: usize) -> anyhow::Result<BusPacket> {
         let val = match off {
-            0x00..=0x10 => self.chan0.read(off)?,
-            0x14..=0x24 => self.chan1.read(off - 0x14)?,
-            0x28..=0x38 => self.chan2.read(off - 0x28)?,
-
-            0x40..=0x7c => self.ppc_bootstrap[(off - 0x40)/4],
-            _ => { bail!("EXI read to undef offset {off:x}"); },
+            0x00..=0x10 => self.channels[0].read(off)?,
+            0x14..=0x24 => self.channels[1].read(off - 0x14)?,
+            0x28..=0x38 => self.channels[2].read(off - 0x28)?,
+            0x40..=0x7c => self.ppc_bootstrap[(off - 0x40) / 4],
+            _ => bail!("EXI read to undef offset {off:x}"),
         };
         Ok(BusPacket::Word(val))
     }
+
     fn write(&mut self, off: usize, val: u32) -> anyhow::Result<Option<BusTask>> {
-        match off { 
-            0x00..=0x10 => self.chan0.write(off, val)?,
-            0x14..=0x24 => self.chan1.write(off - 0x14, val)?,
-            0x28..=0x38 => self.chan2.write(off - 0x28, val)?,
-
-
-            0x40..=0x7c => self.ppc_bootstrap[(off - 0x40)/4] = val,
-            _ => { bail!("EXI write {val:08x} to {off:x}"); },
+        match off {
+            0x00..=0x10 => self.write_channel(0, off, val)?,
+            0x14..=0x24 => self.write_channel(1, off - 0x14, val)?,
+            0x28..=0x38 => self.write_channel(2, off - 0x28, val)?,
+            0x40..=0x7c => self.ppc_bootstrap[(off - 0x40) / 4] = val,
+            _ => bail!("EXI write {val:08x} to {off:x}"),
         }
         Ok(None)
     }
 }
-
-

--- a/core/src/dev/hlwd/compat/exi.rs
+++ b/core/src/dev/hlwd/compat/exi.rs
@@ -139,7 +139,7 @@ impl ChannelState {
 pub struct EXIChannel {
     /// Channel index
     idx: usize,
-    /// Status register value
+    /// Channel Status Register value
     pub csr: u32,
     /// DMA address register value
     pub mar: u32,
@@ -154,6 +154,15 @@ pub struct EXIChannel {
 }
 
 impl EXIChannel {
+    /// CSR bits that are read-only from the guest's point of view:
+    /// EXT (device present, bit 12).
+    const CSR_RO_BITS: u32 = 0x0000_1000;
+    /// CSR interrupt status bits. W1C
+    /// EXIINT - bit  1
+    /// TCINT  - bit  3
+    /// EXTINT - bit 11 
+    const CSR_W1C_BITS: u32 = 0x0000_080a;
+
     pub fn new(idx: usize) -> Self {
         EXIChannel {
             idx, csr: 0, mar: 0, len: 0, data: 0, ctrl: 0,
@@ -163,6 +172,20 @@ impl EXIChannel {
 
     fn update_state(&mut self) {
         self.state = ChannelState::from_chn(self.idx, self.csr, self.ctrl);
+    }
+
+    fn write_csr(&mut self, val: u32) {
+        self.csr = (self.csr & Self::CSR_RO_BITS)
+            | (val & !(Self::CSR_RO_BITS | Self::CSR_W1C_BITS))
+            | (self.csr & Self::CSR_W1C_BITS & !val);
+    }
+
+    /// Assert the transfer-complete interrupt status bit
+    /// TODO: Actual delivery of EXI interrupts to Broadway not implemented
+    /// this seems to be ok since software polls CSR manually (why?) and doesn't rely on interrupts for immediate transfers
+    fn set_transfer_complete(&mut self) {
+        self.csr |= 0x0000_0008;
+        self.update_state();
     }
 
     fn update_csr_device_bits(&mut self, has_device: bool) {
@@ -193,7 +216,7 @@ impl EXIChannel {
     pub fn write(&mut self, off: usize, val: u32) -> anyhow::Result<EXIChannelAction> {
         log::debug!(target: "EXI", "chn{} write {val:08x} at {off:08x}", self.idx);
         match off {
-            0x00 => self.csr = val,
+            0x00 => self.write_csr(val),
             0x04 => self.mar = val,
             0x08 => self.len = val,
             0x0c => self.ctrl = val,
@@ -286,6 +309,7 @@ impl EXInterface {
             EXIChannelAction::ImmediateTransfer(req) => {
                 let result = self.devices[req.channel][req.cs].transfer_imm(req)?;
                 self.channels[req.channel].data = result;
+                self.channels[req.channel].set_transfer_complete();
                 Ok(())
             }
         }

--- a/core/src/dev/hlwd/compat/exi.rs
+++ b/core/src/dev/hlwd/compat/exi.rs
@@ -275,8 +275,10 @@ impl EXInterface {
 
         devices[0][0] = EXIDeviceSlot::MemoryCard(MemoryCardDevice);
         devices[0][1] = EXIDeviceSlot::Rtc(RtcDevice);
-        devices[1][0] = EXIDeviceSlot::UsbGecko(UsbGeckoDevice::default());
         devices[2][0] = EXIDeviceSlot::SdGecko(SdGeckoDevice);
+
+        // NOTE: The USB Gecko is not attached by default
+        // see `attach_usbgecko`
 
         devices
     }
@@ -290,6 +292,12 @@ impl EXInterface {
         };
         exi.refresh_presence_bits();
         exi
+    }
+
+    pub fn attach_usbgecko(&mut self, dev: UsbGeckoDevice) {
+        let (chn, cs) = EXIDeviceKind::UsbGecko.location();
+        self.devices[chn][cs] = EXIDeviceSlot::UsbGecko(dev);
+        self.refresh_presence_bits();
     }
 
     fn refresh_presence_bits(&mut self) {

--- a/core/src/dev/hlwd/compat/exi/device.rs
+++ b/core/src/dev/hlwd/compat/exi/device.rs
@@ -1,23 +1,89 @@
+use super::{EXIFreq, EXITransfer};
+pub mod sdgecko;
+pub mod usbgecko;
+pub mod rtc;
+pub mod memorycard;
+use sdgecko::*;
+use usbgecko::*;
+use rtc::*;
+use memorycard::*;
+
 
 /// Representing a particular EXI device.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EXIDeviceKind {
-    CardSlotA,
-    CardSlotB,
+    MemoryCard,
+    Rtc,
     UsbGecko,
+    SdGecko,
 }
+
 impl EXIDeviceKind {
-    pub fn resolve(idx: usize, cs: u32) -> Option<Self> {
-        match (idx, cs) {
-            (0, 0) => Some(Self::CardSlotA),
-            (1, 0) => Some(Self::CardSlotB),
-            (1, 1) => Some(Self::UsbGecko),
-            (_, _) => None,
+    pub const fn location(self) -> (usize, usize) {
+        match self {
+            Self::MemoryCard => (0, 0),
+            Self::Rtc => (0, 1),
+            Self::UsbGecko => (1, 0),
+            Self::SdGecko => (2, 0),
+        }
+    }
+
+    pub fn resolve(channel: usize, cs: usize) -> Option<Self> {
+        match (channel, cs) {
+            (0, 0) => Some(Self::MemoryCard),
+            (0, 1) => Some(Self::Rtc),
+            (1, 0) => Some(Self::UsbGecko),
+            (2, 0) => Some(Self::SdGecko),
+            _ => None,
         }
     }
 }
 
+/// Decoded information for a single immediate EXI transfer.
+#[derive(Debug, Clone, Copy)]
+pub struct EXITransferRequest {
+    pub channel: usize,
+    pub cs: usize,
+    pub len: u32,
+    pub kind: EXITransfer,
+    pub data: u32,
+    pub clk: EXIFreq,
+}
 
-//pub trait ExiDevice {
-//    fn imm_read(&mut self, gt
-//}
+/// Concrete device storage for a single EXI chip-select line.
+#[derive(Debug, Clone)]
+pub enum EXIDeviceSlot {
+    None,
+    MemoryCard(MemoryCardDevice),
+    Rtc(RtcDevice),
+    UsbGecko(UsbGeckoDevice),
+    SdGecko(SdGeckoDevice),
+}
+
+impl Default for EXIDeviceSlot {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+impl EXIDeviceSlot {
+    pub fn kind(&self) -> Option<EXIDeviceKind> {
+        match self {
+            Self::None => None,
+            Self::MemoryCard(_) => Some(EXIDeviceKind::MemoryCard),
+            Self::Rtc(_) => Some(EXIDeviceKind::Rtc),
+            Self::UsbGecko(_) => Some(EXIDeviceKind::UsbGecko),
+            Self::SdGecko(_) => Some(EXIDeviceKind::SdGecko),
+        }
+    }
+
+    pub fn transfer_imm(&mut self, req: EXITransferRequest) -> anyhow::Result<u32> {
+        match self {
+            Self::None => Ok(0xffff_ffff),
+            Self::MemoryCard(dev) => dev.transfer_imm(req),
+            Self::Rtc(dev) => dev.transfer_imm(req),
+            Self::UsbGecko(dev) => dev.transfer_imm(req),
+            Self::SdGecko(dev) => dev.transfer_imm(req),
+        }
+    }
+}

--- a/core/src/dev/hlwd/compat/exi/device.rs
+++ b/core/src/dev/hlwd/compat/exi/device.rs
@@ -51,19 +51,14 @@ pub struct EXITransferRequest {
 }
 
 /// Concrete device storage for a single EXI chip-select line.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum EXIDeviceSlot {
+    #[default]
     None,
     MemoryCard(MemoryCardDevice),
     Rtc(RtcDevice),
     UsbGecko(UsbGeckoDevice),
     SdGecko(SdGeckoDevice),
-}
-
-impl Default for EXIDeviceSlot {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 impl EXIDeviceSlot {

--- a/core/src/dev/hlwd/compat/exi/device/memorycard.rs
+++ b/core/src/dev/hlwd/compat/exi/device/memorycard.rs
@@ -1,0 +1,12 @@
+use super::EXITransferRequest;
+use log::debug;
+
+#[derive(Debug, Clone, Default)]
+pub struct MemoryCardDevice;
+
+impl MemoryCardDevice {
+    pub fn transfer_imm(&mut self, req: EXITransferRequest) -> anyhow::Result<u32> {
+        debug!(target: "EXI", "stub memory card transfer: {req:?}");
+        Ok(0xffff_ffff)
+    }
+}

--- a/core/src/dev/hlwd/compat/exi/device/rtc.rs
+++ b/core/src/dev/hlwd/compat/exi/device/rtc.rs
@@ -1,0 +1,12 @@
+use super::EXITransferRequest;
+use log::debug;
+
+#[derive(Debug, Clone, Default)]
+pub struct RtcDevice;
+
+impl RtcDevice {
+    pub fn transfer_imm(&mut self, req: EXITransferRequest) -> anyhow::Result<u32> {
+        debug!(target: "EXI", "stub RTC transfer: {req:?}");
+        Ok(0xffff_ffff)
+    }
+}

--- a/core/src/dev/hlwd/compat/exi/device/sdgecko.rs
+++ b/core/src/dev/hlwd/compat/exi/device/sdgecko.rs
@@ -1,0 +1,14 @@
+use super::EXITransferRequest;
+use log::debug;
+
+#[derive(Debug, Clone, Default)]
+pub struct SdGeckoDevice;
+
+impl SdGeckoDevice {
+    pub fn transfer_imm(&mut self, req: EXITransferRequest) -> anyhow::Result<u32> {
+        debug!(target: "EXI", "stub SD Gecko transfer: {req:?}");
+        Ok(0xffff_ffff)
+    }
+}
+
+

--- a/core/src/dev/hlwd/compat/exi/device/usbgecko.rs
+++ b/core/src/dev/hlwd/compat/exi/device/usbgecko.rs
@@ -1,0 +1,12 @@
+use log::debug;
+use super::EXITransferRequest;
+
+#[derive(Debug, Clone, Default)]
+pub struct UsbGeckoDevice;
+
+impl UsbGeckoDevice {
+    pub fn transfer_imm(&mut self, req: EXITransferRequest) -> anyhow::Result<u32> {
+        debug!(target: "EXI", "stub USB Gecko transfer: {req:?}");
+        Ok(0)
+    }
+}

--- a/core/src/dev/hlwd/compat/exi/device/usbgecko.rs
+++ b/core/src/dev/hlwd/compat/exi/device/usbgecko.rs
@@ -1,12 +1,40 @@
-use log::debug;
+use log::{debug, info, warn};
 use super::EXITransferRequest;
+use super::super::EXITransfer;
 
 #[derive(Debug, Clone, Default)]
 pub struct UsbGeckoDevice;
 
+// Mostly implementing what can be gathered about the protocol from the Linux driver:
+// https://github.com/torvalds/linux/blob/master/arch/powerpc/platforms/embedded6xx/usbgecko_udbg.c
+// ... there isn't much in terms of docs for it, sadly.
 impl UsbGeckoDevice {
     pub fn transfer_imm(&mut self, req: EXITransferRequest) -> anyhow::Result<u32> {
-        debug!(target: "EXI", "stub USB Gecko transfer: {req:?}");
-        Ok(0)
+        debug!(target: "UG", "stub USB Gecko transfer: {req:?}");
+        if req.kind != EXITransfer::ReadWrite {
+            warn!(target: "UG", "USB Gecko only does rw transfers");
+            return Ok(0x0000_0000)
+        }
+
+        let cmd = (req.data & 0xf000_0000) >> 28;
+        match cmd {
+            0x9 => Ok(0x0470_0000), // ID
+            0xa => Ok(0x0000_0000), // Read (from computer)
+            0xb => { // Write (to computer)
+                let ch = (((req.data & 0x0ff0_0000) >> 20) as u8) as char;
+                // TODO: output to a file?  recording the output 1 character at a time to the main
+                // log isn't particularly helpful...
+                info!(target: "UG", "got char: {}", ch);
+                // FIXME: Priiloader expects this bit to be set on writes for OSReport-to-USBGecko;
+                // is this right?
+                Ok(0x0400_0000)
+            },
+            0xc => Ok(0x0400_0000), // Check if TX FIFO is ready (it always is here)
+            0xd => Ok(0x0000_0000), // Check if RX FIFO is ready (it never is here, no input support)
+            _ => {
+                warn!(target: "UG", "Unrecognized USB Gecko command: {cmd:x}");
+                Ok(0x0000_0000)
+            }
+        }
     }
 }

--- a/core/src/dev/hlwd/compat/exi/device/usbgecko.rs
+++ b/core/src/dev/hlwd/compat/exi/device/usbgecko.rs
@@ -1,16 +1,42 @@
-use log::{debug, info, warn};
+use log::{debug, error, info, trace, warn};
+use std::collections::VecDeque;
+use std::io::{ErrorKind, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
 use super::EXITransferRequest;
 use super::super::EXITransfer;
 
-#[derive(Debug, Clone, Default)]
-pub struct UsbGeckoDevice;
+// same port used by Dolphin's USB Gecko emulation +1
+pub const USBGECKO_DEFAULT_PORT: u16 = 55021;
+const TX_FIFO_CAP: usize = 0x10000;
+const RX_FIFO_CAP: usize = 0x1000;
 
-// Mostly implementing what can be gathered about the protocol from the Linux driver:
+#[derive(Debug, Default)]
+pub struct UsbGeckoBridge {
+    /// Guest-to-host FIFO
+    tx: Mutex<VecDeque<u8>>,
+    /// Host-to-guest FIFO
+    rx: Mutex<VecDeque<u8>>,
+    /// client connected
+    connected: AtomicBool,
+}
+
+// Mostly implementing what can be gathered about the protocol from libogc
+// `gc/usbgecko.c` and the Linux driver:
 // https://github.com/torvalds/linux/blob/master/arch/powerpc/platforms/embedded6xx/usbgecko_udbg.c
 // ... there isn't much in terms of docs for it, sadly.
+#[derive(Debug, Clone, Default)]
+pub struct UsbGeckoDevice {
+    bridge: Arc<UsbGeckoBridge>,
+}
+
 impl UsbGeckoDevice {
     pub fn transfer_imm(&mut self, req: EXITransferRequest) -> anyhow::Result<u32> {
-        debug!(target: "UG", "stub USB Gecko transfer: {req:?}");
+        debug!(target: "UG", "USB Gecko transfer: {req:?}");
         if req.kind != EXITransfer::ReadWrite {
             warn!(target: "UG", "USB Gecko only does rw transfers");
             return Ok(0x0000_0000)
@@ -18,22 +44,114 @@ impl UsbGeckoDevice {
 
         let cmd = (req.data & 0xf000_0000) >> 28;
         match cmd {
-            0x9 => Ok(0x0470_0000), // ID
-            0xa => Ok(0x0000_0000), // Read (from computer)
-            0xb => { // Write (to computer)
-                let ch = (((req.data & 0x0ff0_0000) >> 20) as u8) as char;
-                // TODO: output to a file?  recording the output 1 character at a time to the main
-                // log isn't particularly helpful...
-                info!(target: "UG", "got char: {}", ch);
-                // FIXME: Priiloader expects this bit to be set on writes for OSReport-to-USBGecko;
-                // is this right?
+            // ID see: libogc `gecko_isalive`
+            0x9 => Ok(0x0470_0000),
+            // Read a byte (host-to-guest). Bit 27 == success, with the
+            // received byte in bits 23:16 see: libogc `gecko_recvbyte`
+            0xa => {
+                let byte = self.bridge.rx.lock().unwrap().pop_front();
+                match byte {
+                    Some(b) => Ok(0x0800_0000 | ((b as u32) << 16)),
+                    None => Ok(0x0000_0000),
+                }
+            },
+            // Write a byte (guest-to-host), from bits 27:20. Bit 26 flags
+            // that the byte was accepted see: libogc `gecko_sendbyte`
+            0xb => {
+                let b = ((req.data & 0x0ff0_0000) >> 20) as u8;
+                if self.bridge.connected.load(Ordering::Relaxed) {
+                    let mut tx = self.bridge.tx.lock().unwrap();
+                    if tx.len() < TX_FIFO_CAP {
+                        tx.push_back(b);
+                    } else { // warning?
+                        debug!(target: "UG", "TX FIFO full, dropping byte {b:02x}");
+                    }
+                } else {
+                    // do not stall guest if there's no one listening
+                    trace!(target: "UG", "no client, dropping byte {b:02x}");
+                }
                 Ok(0x0400_0000)
             },
-            0xc => Ok(0x0400_0000), // Check if TX FIFO is ready (it always is here)
-            0xd => Ok(0x0000_0000), // Check if RX FIFO is ready (it never is here, no input support)
+            // Check if TX FIFO is ready (it always is here)
+            0xc => Ok(0x0400_0000), 
+            // Check if RX FIFO is ready: bit 26 set when data is available
+            0xd => Ok((!self.bridge.rx.lock().unwrap().is_empty() as u32) << 26),
             _ => {
                 warn!(target: "UG", "Unrecognized USB Gecko command: {cmd:x}");
                 Ok(0x0000_0000)
+            }
+        }
+    }
+
+    // serve this gecko's serial stream on TCP socket bound to `127.0.0.1:port`.
+    // One client at a time pls
+    // todo: move this out of core?
+    pub fn spawn_server_thread(&self, port: u16) -> anyhow::Result<JoinHandle<()>> {
+        let listener = TcpListener::bind(("127.0.0.1", port))?;
+        self.spawn_server_thread_on(listener)
+    }
+
+    // Spawn the host-side I/O thread on an already-bound listener.
+    // see above
+    pub fn spawn_server_thread_on(&self, listener: TcpListener) -> anyhow::Result<JoinHandle<()>> {
+        info!(target: "UG", "USB Gecko server listening on {}", listener.local_addr()?);
+        let bridge = self.bridge.clone();
+        let handle = std::thread::Builder::new()
+            .name("GeckoThread".to_owned())
+            .spawn(move || Self::server_loop(bridge, listener))?;
+        Ok(handle)
+    }
+
+    fn server_loop(bridge: Arc<UsbGeckoBridge>, listener: TcpListener) {
+        loop {
+            let (stream, peer) = match listener.accept() {
+                Ok(x) => x,
+                Err(e) => {
+                    // todo relaunch like ppc server
+                    error!(target: "UG", "accept() failed: {e}; USB Gecko server exiting");
+                    return;
+                },
+            };
+            info!(target: "UG", "client connected from {peer}");
+            bridge.connected.store(true, Ordering::Relaxed);
+            if let Err(e) = Self::handle_client(&bridge, stream) {
+                debug!(target: "UG", "client i/o error: {e}");
+            }
+            bridge.connected.store(false, Ordering::Relaxed);
+            info!(target: "UG", "client disconnected");
+        }
+    }
+
+    fn handle_client(bridge: &UsbGeckoBridge, mut stream: TcpStream) -> anyhow::Result<()> {
+        stream.set_read_timeout(Some(Duration::from_millis(5)))?;
+        stream.set_nodelay(true)?;
+        let mut buf = [0u8; 0x1000];
+        loop {
+            // TX first
+            let pending: Vec<u8> = { // FIXME: don't alloc here every time
+                let mut tx = bridge.tx.lock().unwrap();
+                tx.drain(..).collect()
+            };
+            if !pending.is_empty() {
+                stream.write_all(&pending)?;
+            }
+
+            let space = RX_FIFO_CAP.saturating_sub(bridge.rx.lock().unwrap().len());
+            if space == 0 {
+                // shouldn't really happen that much but FIXME don't sleep in IO threads
+                std::thread::sleep(Duration::from_millis(5));
+                continue;
+            }
+            let max = space.min(buf.len());
+            match stream.read(&mut buf[..max]) {
+                Ok(0) => return Ok(()),
+                Ok(n) => {
+                    let mut rx = bridge.rx.lock().unwrap();
+                    rx.extend(&buf[..n]);
+                },
+                Err(e) if matches!(e.kind(),
+                    ErrorKind::WouldBlock | ErrorKind::TimedOut | ErrorKind::Interrupted) => {},
+                Err(e) => return Err(e.into()),
             }
         }
     }

--- a/pyronic/usbgecko.py
+++ b/pyronic/usbgecko.py
@@ -1,0 +1,51 @@
+from struct import pack, unpack
+from pyronic.client import *
+
+ipc = IPCClient()
+sock = ipc.sock
+
+regs_arr = [ 0x0d806800, 0x0d806814, 0x0d806828 ]
+CSR = 0
+MAR = 4
+LENGTH = 8
+CR = 12
+DATA = 16
+
+def exi_init(ch):
+    regs = regs_arr[ch]
+
+    sock.send_ppc_write32(regs + CSR, 0b101 << 4)
+
+def exi_xfer(ch, cs, tx):
+    regs = regs_arr[ch]
+
+    res = sock.send_ppc_read32(regs + CSR)
+    val = unpack(">L", res)[0]
+    val = val & 0x3c7f
+    val = val | (1 << (7 + cs))
+    res = sock.send_ppc_write32(regs + CSR, val)
+
+    sock.send_ppc_write32(regs + DATA, tx)
+    sock.send_ppc_write32(regs + CR, 0b111001)
+    while True:
+        res = sock.send_ppc_read32(regs + CR)
+        val = unpack(">L", res)[0]
+        if not (val & 0x00000001):
+            break
+
+    res = sock.send_ppc_read32(regs + DATA)
+    val = unpack(">L", res)[0]
+    return val
+
+def ug_putc(ch, cs, c):
+    exi_xfer(ch, cs, 0xb0000000 | (int(ord(c)) << 20))
+
+def ug_puts(ch, cs, msg):
+    for c in msg:
+        ug_putc(ch, cs, c)
+
+
+exi_init(1)
+id = exi_xfer(1, 0, 0x90000000)
+print("USB Gecko ID: " + hex(id))
+ug_puts(1, 0, "hello")

--- a/pyronic/usbgecko.py
+++ b/pyronic/usbgecko.py
@@ -1,51 +1,97 @@
-from struct import pack, unpack
-from pyronic.client import *
+#!/usr/bin/env python3
+import argparse
+import os
+import select
+import socket
+import sys
+import time
 
-ipc = IPCClient()
-sock = ipc.sock
+# Ctrl-], as in telnet
+ESCAPE = 0x1d
 
-regs_arr = [ 0x0d806800, 0x0d806814, 0x0d806828 ]
-CSR = 0
-MAR = 4
-LENGTH = 8
-CR = 12
-DATA = 16
 
-def exi_init(ch):
-    regs = regs_arr[ch]
-
-    sock.send_ppc_write32(regs + CSR, 0b101 << 4)
-
-def exi_xfer(ch, cs, tx):
-    regs = regs_arr[ch]
-
-    res = sock.send_ppc_read32(regs + CSR)
-    val = unpack(">L", res)[0]
-    val = val & 0x3c7f
-    val = val | (1 << (7 + cs))
-    res = sock.send_ppc_write32(regs + CSR, val)
-
-    sock.send_ppc_write32(regs + DATA, tx)
-    sock.send_ppc_write32(regs + CR, 0b111001)
+def connect(host, port, wait):
+    printed = False
     while True:
-        res = sock.send_ppc_read32(regs + CR)
-        val = unpack(">L", res)[0]
-        if not (val & 0x00000001):
-            break
+        try:
+            sock = socket.create_connection((host, port))
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            return sock
+        except OSError as e:
+            if not wait:
+                print(f"usbgecko: can't connect to {host}:{port}: {e}",
+                      file=sys.stderr)
+                print("usbgecko: is ironic running with --usbgecko? "
+                      "(-w retries until it is)", file=sys.stderr)
+                sys.exit(1)
+            if not printed:
+                print(f"usbgecko: waiting for {host}:{port} ...",
+                      file=sys.stderr)
+                printed = True
+            time.sleep(0.5)
 
-    res = sock.send_ppc_read32(regs + DATA)
-    val = unpack(">L", res)[0]
-    return val
 
-def ug_putc(ch, cs, c):
-    exi_xfer(ch, cs, 0xb0000000 | (int(ord(c)) << 20))
+def pump(sock, escape_active):
+    """ Shuttle bytes between stdin/stdout and the gecko socket.
+    Returns when the connection drops or (if escape_active) on Ctrl-]. """
+    stdin_fd = sys.stdin.fileno()
+    stdin_open = True
+    while True:
+        fds = [sock] + ([stdin_fd] if stdin_open else [])
+        readable, _, _ = select.select(fds, [], [])
+        if sock in readable:
+            data = sock.recv(4096)
+            if not data:
+                return
+            sys.stdout.buffer.write(data)
+            sys.stdout.buffer.flush()
+        if stdin_fd in readable:
+            data = os.read(stdin_fd, 4096)
+            if not data:
+                # EOF on piped input: keep printing guest output
+                stdin_open = False
+                continue
+            if escape_active and ESCAPE in data:
+                sock.sendall(data[:data.index(ESCAPE)])
+                return
+            sock.sendall(data)
 
-def ug_puts(ch, cs, msg):
-    for c in msg:
-        ug_putc(ch, cs, c)
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Terminal client for ironic's emulated USB Gecko")
+    parser.add_argument("--host", default="127.0.0.1",
+                        help="host to connect to (default: 127.0.0.1)")
+    parser.add_argument("-p", "--port", type=int, default=55021,
+                        help="TCP port of the gecko server (default: 55021)")
+    parser.add_argument("-w", "--wait", action="store_true",
+                        help="retry until the gecko server is reachable")
+    args = parser.parse_args()
+
+    sock = connect(args.host, args.port, args.wait)
+
+    if sys.stdin.isatty():
+        import termios
+        import tty
+        print(f"usbgecko: connected to {args.host}:{args.port}, "
+              "escape character is Ctrl-]", file=sys.stderr)
+        saved = termios.tcgetattr(sys.stdin.fileno())
+        tty.setraw(sys.stdin.fileno())
+        mode = termios.tcgetattr(sys.stdin.fileno())
+        mode[1] |= termios.OPOST | termios.ONLCR  # oflags prevent staircasing
+        termios.tcsetattr(sys.stdin.fileno(), termios.TCSADRAIN, mode)
+        try:
+            pump(sock, escape_active=True)
+        finally:
+            termios.tcsetattr(sys.stdin.fileno(), termios.TCSADRAIN, saved)
+            print("\nusbgecko: detached", file=sys.stderr)
+    else:
+        try:
+            pump(sock, escape_active=False)
+        except KeyboardInterrupt:
+            pass
+        print("usbgecko: connection closed", file=sys.stderr)
 
 
-exi_init(1)
-id = exi_xfer(1, 0, 0x90000000)
-print("USB Gecko ID: " + hex(id))
-ug_puts(1, 0, "hello")
+if __name__ == "__main__":
+    main()

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -4,6 +4,7 @@ use addr2line::Context;
 use gimli::BigEndian;
 use gimli::EndianSlice;
 use ironic_core::bus::*;
+use ironic_core::dev::hlwd::compat::exi::device::usbgecko::UsbGeckoDevice;
 use ironic_core::dev::hlwd::compat::vi::VideoInterface;
 use ironic_backend::interp::*;
 use ironic_backend::back::*;
@@ -34,6 +35,11 @@ struct Args {
     /// Enable the PPC HLE server (default = False)
     #[clap(short, long)]
     ppc_hle: bool,
+    /// Attach an emulated USB Gecko whose serial stream is
+    /// served over TCP on 127.0.0.1 port 55021 by default
+    /// When this flag is absent, guest software sees an empty slot.
+    #[clap(short, long, value_name = "PORT", num_args = 0..=1, default_missing_value = "55021")]
+    usbgecko: Option<u16>,
     /// Define log levels for the program
     #[clap(long, default_value="info")]
     logging: String,
@@ -46,13 +52,25 @@ fn main() -> anyhow::Result<()> {
     let enable_ppc_hle = args.ppc_hle;
 
     // The bus is shared between any threads we spin up
-    let bus = match Bus::new() {
+    let mut bus = match Bus::new() {
         Ok(val) => val,
         Err(reason) => {
             println!("Failed to construct emulator Bus: {reason}");
             process::exit(-1);
         }
     };
+
+    // TODO: rework this into a Backend.
+    if let Some(port) = args.usbgecko {
+        let gecko = UsbGeckoDevice::default();
+        match gecko.spawn_server_thread(port) {
+            Ok(_) => bus.hlwd.exi.attach_usbgecko(gecko),
+            Err(reason) => {
+                println!("Failed to start USB Gecko server on port {port}: {reason}");
+                process::exit(-1);
+            }
+        }
+    }
 
     let bus = Arc::new(RwLock::new(bus));
     let _vi_thread = VideoInterface::spawn_irq_thread(bus.clone()).unwrap();
@@ -192,6 +210,7 @@ enum LogTarget {
     SHA,
     SYSCALL,
     SVC,
+    UG,
     xHCI,
     RTPATCH,
     Other,


### PR DESCRIPTION
Previously, I couldn't really see much of any way that one could actually have a stateful device over EXI, or even really pull off transfers at all, so it needed a pretty big rework there (of which I still don't know if this is the best way to handle it, though it does work); also opens the door to implementing other devices in the future (as you can see I've made stubs for some as examples for what else should probably be implemented at some point).  USB Gecko doesn't actually use it yet, but it probably will once it starts writing to a file and it needs to track state regarding that; as will thge others.

Currently this is good enough that with my simple test script with Pyronic, I can get it to actually see characters getting written, and can get the gecko ID.  I've yet to test this with actual PPC software on the LLE, but I'd imagine it'd work there as well.

Ideas for how best to implement logs from USB Gecko are very welcome (hold on to characters until they form a full line, then output to main log?  write directly to a file?  etc).