### PR TITLE
GPIO: Full PPC GPIOs, stub AVE + Sensor Bar

### DIFF
--- a/core/src/dev/hlwd.rs
+++ b/core/src/dev/hlwd.rs
@@ -268,7 +268,7 @@ impl MmioDevice for Hollywood {
             0x060           => self.busctrl.srnprot,
             0x064           => self.busctrl.ahbprot,
             0x070           => self.busctrl.aipprot,
-            0x0c0..=0x0d8   => self.gpio.ppc.read_handler(off - 0xc0)?,
+            0x0c0..=0x0d8   => self.gpio.ppc.read_handler(&self.gpio.arm, off - 0xc0)?,
             0x0dc..=0x0fc   => self.gpio.arm.read_handler(off - 0xdc)?,
             0x100..=0x13c   => self.arb.read_handler(off - 0x100)?,
             0x180           => self.compat,
@@ -319,7 +319,9 @@ impl MmioDevice for Hollywood {
             0x064 => self.busctrl.ahbprot = val,
             0x070 => self.busctrl.aipprot = val,
             0x088 => self.usb_frc_rst = val,
-            0x0c0..=0x0d8 => self.gpio.ppc.write_handler(off - 0xc0, val)?,
+            0x0c0..=0x0d8 => {
+                self.task = self.gpio.ppc.write_handler(&mut self.gpio.arm, off - 0xc0, val)?;
+            },
             0x0dc..=0x0fc => {
                 self.task = self.gpio.arm.write_handler(off - 0xdc, val)?;
             },
@@ -466,5 +468,4 @@ impl Bus {
         Ok(())
     }
 }
-
 

--- a/core/src/dev/hlwd/gpio.rs
+++ b/core/src/dev/hlwd/gpio.rs
@@ -55,8 +55,28 @@ impl GpioInterface {
             info!(target: "Other", "GPIO Fan/DCDC output {diff:08x}");
         } else if (diff & 0x0000_0020) != 0 {
             info!(target: "Other", "GPIO Disc Slot LED output");
-        }
-        else {
+        } else if (diff & 0x0000_0100) != 0 {
+            if (val & 0x0000_0100) != 0 {
+                info!(target: "Other", "GPIO Sensor Bar On");
+            }
+            else {
+                info!(target: "Other", "GPIO Sensors Bar Off");
+            }
+        } else if (diff & 0x0000_4000) != 0 { // FIXME: actually emulate the AVE's i2c comms
+            if (val & 0x0000_4000) != 0 {
+                info!(target: "Other", "GPIO AVE Clock High");
+            }
+            else {
+                info!(target: "Other", "GPIO AVE Clock Low");
+            }
+        } else if (diff & 0x0000_8000) != 0 {
+            if (val & 0x0000_8000) != 0 {
+                info!(target: "Other", "GPIO AVE Data: 1");
+            }
+            else {
+                info!(target: "Other", "GPIO AVE Data: 0");
+            }
+        } else {
             bail!("Unhandled GPIO output arm.output={:08x} val={val:08x} diff={diff:08x}", self.arm.output);
         }
         Ok(())
@@ -131,20 +151,40 @@ pub struct PpcGpio {
     straps: u32,
 }
 impl PpcGpio {
-    pub fn write_handler(&mut self, off: usize, data: u32) -> anyhow::Result<()> {
+    pub fn write_handler(&self, arm: &mut ArmGpio, off: usize, data: u32) -> anyhow::Result<Option<HlwdTask>> {
+        let owner = arm.owner;
         match off {
-            0x00 => self.output = data,
-            0x04 => self.dir = data,
+            0x00 => {
+                let output = (arm.output & !owner) | (data & owner);
+                let task = if (arm.output ^ output) != 0 {
+                    Some(HlwdTask::GpioOutput(output))
+                } else {
+                    None
+                };
+                return Ok(task);
+            },
+            0x04 => arm.dir = arm.dir | (data & owner),
+            0x08 => { bail!("CPU wrote to GPIO inputs!?".to_string()); },
+            0x0c => arm.intlvl = arm.intlvl | (data & owner),
+            0x10 => arm.intflag = arm.intflag | (data & owner),
+            0x14 => arm.intmask = arm.intmask | (data & owner),
+            0x18 => arm.straps = arm.straps | (data & owner),
             _ => error!(target: "Other", "FIXME: unimplemented PpcGpio write {off:08x}: 0x{data:08x}"),
         };
-        Ok(())
+        Ok(None)
     }
-    pub fn read_handler(&self, off: usize) -> anyhow::Result<u32> {
+    pub fn read_handler(&self, arm: &ArmGpio, off: usize) -> anyhow::Result<u32> {
+        let owner = arm.owner;
         Ok(match off {
-            0x00 => self.output,
-            0x04 => self.dir,
+            0x00 => arm.output & owner,
+            0x04 => arm.dir & owner,
+            0x08 => arm.input & owner,
+            0x0c => arm.intlvl & owner,
+            0x10 => 0x0000_0000, //arm.intflag,
+            0x14 => arm.intmask & owner,
+            0x18 => arm.straps & owner,
             _ => { bail!("unimplemented PpcGpio read {off:08x}"); },
-        })
+        } & owner)
     }
 }
 


### PR DESCRIPTION
Good enough to let libogc run video initialization.  Will eventually need to really implement the AVE but this is good enough for now.  This may or may not be the best way to allow PPC GPIOs to actually impact the real GPIO state; open to suggestions for better solutions.