### PR TITLE
Core,Pyronic,Cronic: Cleanup XFB dump

### DIFF
--- a/back/src/ppc.rs
+++ b/back/src/ppc.rs
@@ -372,8 +372,8 @@ impl PpcBackend {
         }
 
         let payload_len = match req.cmd {
-            // HostWrite carries `len` bytes inline after the header.
-            Command::HostWrite => req.len as usize,
+            // These commands carry `len` bytes inline after the header.
+            Command::HostWrite | Command::DumpXfb => req.len as usize,
             // Raw PPC writes also carry the value inline after the header.
             Command::PPCWrite8 => 1,
             Command::PPCWrite16 => 2,
@@ -516,12 +516,10 @@ impl PpcBackend {
     }
 
     pub fn handle_dump_xfb(&mut self, client: &mut UnixStream, req: SocketReq) -> anyhow::Result<()> {
-        let bus = self.bus.read();
-        let bytes = bus.dump_xfb();
-        let mut pb = vec!(0u8; req.len as usize);
-        bus.dma_read(req.addr, &mut pb)?;
-        drop(bus);
-        let path = PathBuf::from(str::from_utf8(&pb)?);
+        let bytes = self.bus.read().dump_xfb();
+        let pathstr = str::from_utf8(&self.ibuf[0xc..(0xc + req.len as usize)])?;
+        let path = PathBuf::from(pathstr);
+        info!(target: "PPC", "Dumping XFB to {pathstr}");
         if let Err(e) = std::fs::write(path, &bytes) {
             let _ = client.write_all(b"F1");
             return Err(anyhow!(e));

--- a/cronic/broadway-lle.c
+++ b/cronic/broadway-lle.c
@@ -496,7 +496,11 @@ Commands:\r\n\
 				\"ifetch\",\"decode\", \"branch\",\r\n\
 				\"loadstore\", \"cache\", or \"misc\", and\r\n\
 				[level] is one of \"debug\", \"verbose\",\r\n\
-				\"info\", \"warn\", or \"error\".");
+				\"info\", \"warn\", or \"error\".\r\n\
+\r\n\
+	xfbdump <path>		Dump the current XFB to <path>.\r\n\
+				If omitted, the path defaults to\r\n\
+				xfb.bmp.");
 }
 
 
@@ -896,6 +900,13 @@ static void debugger(struct ppcemu_state *emu) {
 		}
 
 		ppcemu_set_loglevel(source, level);
+	}
+	else if (!strcmp(cmd, "xfbdump")) {
+		arg = strtok(NULL, " ");
+		if (!arg)
+			arg = "xfb.bmp";
+
+		IPC_DumpXFB(arg);
 	}
 	else if (!strcmp(cmd, "r") || !strcmp(cmd, "run")) {
 		if (started) {

--- a/cronic/cronic.c
+++ b/cronic/cronic.c
@@ -334,15 +334,19 @@ void IPC_Write(uint32_t addr, void *data, unsigned int len) {
 	}
 }
 
-void IPC_DumpXFB(char* const path) {
-	// FIXME: Allocate a real address. Chosen not to interfere with pyronic...
-	IPC_Write(0x01780000, path, strlen(path));
-	if (IPC_Err)
-		return;
-	msg.u32[0] = cronic_cpu_to_le32(17);
-	msg.u32[1] = cronic_cpu_to_le32(0x01780000);
-	msg.u32[2] = cronic_cpu_to_le32(strlen(path));
+void IPC_DumpXFB(char const* path) {
+	size_t path_len = strlen(path);
+	ssize_t written;
+
+	msg.u32[0] = cronic_cpu_to_le32(IRONIC_DUMP_XFB);
+	msg.u32[1] = 0;
+	msg.u32[2] = cronic_cpu_to_le32(path_len);
 	if (write(IPC_Sock, &msg, 12) != 12) {
+		IPC_Err = 1;
+		return;
+	}
+	written = write(IPC_Sock, path, path_len);
+	if (written < 0 || (size_t)written != path_len) {
 		IPC_Err = 1;
 		return;
 	}

--- a/cronic/cronic.h
+++ b/cronic/cronic.h
@@ -57,6 +57,6 @@ extern void IPC_Write(uint32_t addr, void *data, unsigned int len);
 extern void IPC_EnableFlipperIrqs(IPC_IrqCallback callback);
 extern void IPC_PollFlipperIrq(void);
 
-extern void IPC_DumpXFB(char* const path);
+extern void IPC_DumpXFB(char const* path);
 
 #endif /* _CRONIC_CRONIC_H */

--- a/pyronic/pyronic/client.py
+++ b/pyronic/pyronic/client.py
@@ -94,8 +94,7 @@ class IPCClient(object):
         self.sock.send_disableprot()
 
     def dump_xfb(self, path: str):
-        path = self.alloc_buf(path)
-        self.sock.send_xfbdump(path)
+        self.sock.send_xfbdump(path.encode('utf-8'))
 
     def IOSOpen(self, inpath, mode=0):
         buf = self.alloc_buf(inpath.encode('utf-8') + b'\x00')

--- a/pyronic/pyronic/socket.py
+++ b/pyronic/pyronic/socket.py
@@ -155,9 +155,10 @@ class IronicSocket(object):
         resp = self.recv(2)
         assert resp.decode('utf-8') == "OK"
 
-    def send_xfbdump(self, path: MemHandle):
+    def send_xfbdump(self, path: bytes):
         msg = bytearray()
-        msg += pack("<LLL", self.IRONIC_DUMPXFB, path.paddr, path.size)
+        msg += pack("<LLL", self.IRONIC_DUMPXFB, 0, len(path))
+        msg += path
         self.socket.sendall(msg)
         resp = self.recv(2)
         assert resp.decode('utf-8') == "OK"
@@ -175,6 +176,5 @@ class IronicSocket(object):
         self.socket.sendall(msg)
         resp = self.recv(2)
         assert resp.decode('utf-8') == "OK"
-
 
 


### PR DESCRIPTION
* Don't trash memory to store path, pass it inline
* Log where it's being dumped to
* Implement xfbdump command in Broadway LLE