### PR TITLE
Bus fixes

### DIFF
--- a/core/src/bus/decode.rs
+++ b/core/src/bus/decode.rs
@@ -61,14 +61,14 @@ impl Bus {
             0xfffe |
             0xffff => self.resolve_sram(addr),
 
-            0x0d01 => Some(NAND_HANDLE),
-            0x0d02 => Some(AES_HANDLE),
-            0x0d03 => Some(SHA_HANDLE),
-            0x0d04 => Some(EHCI_HANDLE),
-            0x0d05 => Some(OHCI0_HANDLE),
-            0x0d06 => Some(OHCI1_HANDLE),
-            0x0d07 => Some(SDHC0_HANDLE),
-            0x0d08 => Some(SDHC1_HANDLE),
+            0x0d01 | 0x0d81 => Some(NAND_HANDLE),
+            0x0d02 | 0x0d82 => Some(AES_HANDLE),
+            0x0d03 | 0x0d83 => Some(SHA_HANDLE),
+            0x0d04 | 0x0d84 => Some(EHCI_HANDLE),
+            0x0d05 | 0x0d85 => Some(OHCI0_HANDLE),
+            0x0d06 | 0x0d86 => Some(OHCI1_HANDLE),
+            0x0d07 | 0x0d87 => Some(SDHC0_HANDLE),
+            0x0d08 | 0x0d88 => Some(SDHC1_HANDLE),
 
             0x0c00 | 0x0d00 |
             0x0d80 | 0x0d8b => self.resolve_hlwd(addr),

--- a/core/src/bus/decode.rs
+++ b/core/src/bus/decode.rs
@@ -91,6 +91,7 @@ impl Bus {
             VI_BASE..=VI_TAIL       => Some(VI_HANDLE),
             PI_BASE..=PI_TAIL       => Some(PI_HANDLE),
             DSP_BASE..=DSP_TAIL     => Some(DSP_HANDLE),
+            DI_REG_BASE..=DI_REG_TAIL |
             DI_BASE..=DI_TAIL       => Some(DI_HANDLE),
             SI_REG_BASE..=SI_REG_TAIL |
             SI_BASE..=SI_TAIL       => Some(SI_HANDLE),

--- a/core/src/dev.rs
+++ b/core/src/dev.rs
@@ -41,6 +41,7 @@ pub const MI_BASE:      u32 = 0x0c00_4000;
 pub const DSP_BASE:     u32 = 0x0c00_5000;
 
 pub const HLWD_REG_BASE:u32 = 0x0d00_0000;
+pub const DI_REG_BASE:  u32 = 0x0d00_6000;
 pub const SI_REG_BASE:  u32 = 0x0d00_6400;
 pub const EXI_REG_BASE: u32 = 0x0d00_6800;
 pub const AI_REG_BASE:  u32 = 0x0d00_6c00;
@@ -78,6 +79,7 @@ pub const PI_TAIL:      u32 = PI_BASE + HLWDEV_SIZE - 1;
 pub const MI_TAIL:      u32 = MI_BASE + HLWDEV_SIZE - 1;
 pub const DSP_TAIL:     u32 = DSP_BASE + HLWDEV_SIZE - 1;
 pub const HLWD_REG_TAIL:u32 = HLWD_REG_BASE + AHB_SIZE - 1;
+pub const DI_REG_TAIL:  u32 = DI_REG_BASE + HLWDEV_SIZE - 1;
 pub const SI_REG_TAIL:  u32 = SI_REG_BASE + HLWDEV_SIZE - 1;
 //pub const EXI_REG_TAIL: u32 = EXI_REG_BASE + HLWDEV_SIZE - 1;
 pub const AI_REG_TAIL:  u32 = AI_REG_BASE + COREDEV_SIZE - 1;


### PR DESCRIPTION
Permit access via various mirrored regions (which were previously only mapped for unprivilleged), and add unprivilleged DI.