### PR TITLE
Core: fix MEM1 aliasing

### DIFF
--- a/core/src/bus/decode.rs
+++ b/core/src/bus/decode.rs
@@ -24,7 +24,17 @@ macro_rules! decl_io_handle {
 // These are declarations of all the constant DeviceHandle structures whose 
 // parameters (base address, size, etc.) will never change during runtime.
 
-decl_mem_handle!(MEM1_HANDLE, Mem1, 0x017f_ffff);
+/*
+ * MEM1 is 24MB (0x0180_0000), which is *not* a power of two, so it can't use
+ * a plain `size - 1` AND-mask for offset calculation (0x017f_ffff has bit 23
+ * clear, so masking with it silently aliases any address with bit 23 set
+ * 8MB lower, e.g. 0x00906e00 & 0x017fffff == 0x00106e00). The real
+ * 0000..=0x017f high-bits range check in decode_phys_addr() below already
+ * bounds this correctly to the true 24MB, so widening this mask to the next
+ * power of two (32MB - 1) just makes it a no-op for every valid MEM1
+ * address, with no aliasing.
+ */
+decl_mem_handle!(MEM1_HANDLE, Mem1, 0x01ff_ffff);
 decl_mem_handle!(MEM2_HANDLE, Mem2, 0x03ff_ffff);
 
 decl_io_handle!(NAND_HANDLE, Nand,  0x0000_001f);

--- a/core/src/bus/decode.rs
+++ b/core/src/bus/decode.rs
@@ -24,16 +24,6 @@ macro_rules! decl_io_handle {
 // These are declarations of all the constant DeviceHandle structures whose 
 // parameters (base address, size, etc.) will never change during runtime.
 
-/*
- * MEM1 is 24MB (0x0180_0000), which is *not* a power of two, so it can't use
- * a plain `size - 1` AND-mask for offset calculation (0x017f_ffff has bit 23
- * clear, so masking with it silently aliases any address with bit 23 set
- * 8MB lower, e.g. 0x00906e00 & 0x017fffff == 0x00106e00). The real
- * 0000..=0x017f high-bits range check in decode_phys_addr() below already
- * bounds this correctly to the true 24MB, so widening this mask to the next
- * power of two (32MB - 1) just makes it a no-op for every valid MEM1
- * address, with no aliasing.
- */
 decl_mem_handle!(MEM1_HANDLE, Mem1, 0x01ff_ffff);
 decl_mem_handle!(MEM2_HANDLE, Mem2, 0x03ff_ffff);
 

--- a/core/src/dev.rs
+++ b/core/src/dev.rs
@@ -30,7 +30,9 @@ pub const AHB_SIZE:     u32 = 0x0000_4000;
 
 // Base addresses for physical memory devices.
 pub const MEM1_BASE:    u32 = 0x0000_0000;
-pub const MEM1_MASK:    u32 = 0x017f_ffff;
+// MEM1_SIZE (24MB) isn't a power of two, so `size - 1` is not a valid
+// AND-mask.  See the comment on MEM1_HANDLE in bus/decode.rs.
+pub const MEM1_MASK:    u32 = 0x01ff_ffff;
 
 pub const MEM2_BASE:    u32 = 0x1000_0000;
 pub const MEM2_MASK:    u32 = 0x03ff_ffff;

--- a/core/src/dev.rs
+++ b/core/src/dev.rs
@@ -30,8 +30,6 @@ pub const AHB_SIZE:     u32 = 0x0000_4000;
 
 // Base addresses for physical memory devices.
 pub const MEM1_BASE:    u32 = 0x0000_0000;
-// MEM1_SIZE (24MB) isn't a power of two, so `size - 1` is not a valid
-// AND-mask.  See the comment on MEM1_HANDLE in bus/decode.rs.
 pub const MEM1_MASK:    u32 = 0x01ff_ffff;
 
 pub const MEM2_BASE:    u32 = 0x1000_0000;


### PR DESCRIPTION
Fix an aliasing bug in MEM1 due to the masking technique used not working given the size of MEM1.